### PR TITLE
making the cli more user friendly for inexperienced users #662

### DIFF
--- a/cli/lightning-cli.c
+++ b/cli/lightning-cli.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
 	configdir_register_opts(ctx, &lightning_dir, &rpc_filename);
 
 	opt_register_noarg("--help|-h", opt_usage_and_exit,
-			   "<command> [<params>...]", "Show this message");
+			   "<command> [<params>...]", "Show this message\t use the command help (without hyphen) to get a list of all commands");
 	opt_register_version();
 
 	opt_early_parse(argc, argv, opt_log_stderr_exit);


### PR DESCRIPTION
providing a quickfix for https://github.com/ElementsProject/lightning/issues/662

Basically I extended the ./lighting-cli --help message to at least state that one should use ./lighting-cli help